### PR TITLE
F#src 5940 remove num of sensor check

### DIFF
--- a/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
+++ b/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
@@ -493,24 +493,13 @@ int main(int argc, char** argv) {
         retval = device->fill_pno_data(&transformStamped, station_number);
         if (product_type == "viper")
         {
-          if (hands == "right")
+          if (station_number < 8)
           {
             transformStamped.header.frame_id = "polhemus_base_0";
           }
-          else if (hands == "left")
+          else
           {
             transformStamped.header.frame_id = "polhemus_base_1";
-          }
-          else if (hands == "both")
-          {
-            if (station_number < 8)
-            {
-              transformStamped.header.frame_id = "polhemus_base_0";
-            }
-            else
-            {
-              transformStamped.header.frame_id = "polhemus_base_1";
-            }
           }
         }
         else

--- a/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
+++ b/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
@@ -56,6 +56,7 @@
 #define LIBERTY_PRODUCT 0xff20
 #define VIPER_PRODUCT 0xbf01
 
+#define FIRST_STATION_NUMBER_LINKED_TO_LEFT_HAND 8
 
 typedef struct _vp_usbdevinfo {
   int usbDevIndex;
@@ -493,7 +494,11 @@ int main(int argc, char** argv) {
         retval = device->fill_pno_data(&transformStamped, station_number);
         if (product_type == "viper")
         {
-          if (station_number < 8)
+          // We publish the first 5 sensors with frame_id polhemus_base_0 since they are
+          // linked to the first source and to the right hand. The rest of the sensors 
+          // are linked to the second source placed on the left hand.
+          // TODO: check if there is there is a way to get that info from api
+          if (station_number < FIRST_STATION_NUMBER_LINKED_TO_LEFT_HAND)
           {
             transformStamped.header.frame_id = "polhemus_base_0";
           }

--- a/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
+++ b/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
@@ -368,12 +368,6 @@ int main(int argc, char** argv) {
     ROS_INFO("[POLHEMUS] Found %d stations.", device->station_count);
     nstations = device->station_count;
   }
-
-  if ((hands == "both" && nstations != 2*SENSORS_PER_GLOVE) || (hands != "both" && nstations != SENSORS_PER_GLOVE))
-  {
-    ROS_ERROR("[POLHEMUS] Number of sensors detected do not match the number expected.");
-    return -1;
-  }
   
   // define quaternion data type
   ROS_INFO("[POLHEMUS] Setting data type to quaternion");


### PR DESCRIPTION
Remove check for number of sensors. This change allows driver to publish the number of sensors that are connected to the polhemus box without exiting.