### PR TITLE
B fix reset boresight

### DIFF
--- a/src/polhemus_ros_driver/polhemus.cpp
+++ b/src/polhemus_ros_driver/polhemus.cpp
@@ -86,7 +86,8 @@ int Polhemus::device_init(void)
 
 int Polhemus::device_send(uint8_t *cmd, int &count)
 {
-  if (device_write(cmd, count, TIMEOUT))
+  int retval = device_write(cmd, count, TIMEOUT);
+  if (RETURN_ERROR == retval)
   {
     ROS_WARN("[POLHEMUS] Sending cmd `%d' to device failed", *cmd);
     return RETURN_ERROR;
@@ -159,20 +160,22 @@ int Polhemus::set_device_for_calibration(void)
 {
   int retval = RETURN_ERROR;
 
-    reset_boresight();
+  reset_boresight();
+  reset_boresight();
+  reset_boresight();
 
+  retval = receive_pno_data_frame();
+  ros::Time start_time = ros::Time::now();
+
+  while (retval < SENSORS_PER_GLOVE)
+  {
     retval = receive_pno_data_frame();
-    ros::Time start_time = ros::Time::now();
-
-    while (retval < SENSORS_PER_GLOVE)
+    if (ros::Time::now().toSec() - start_time.toSec() >= CALIBRATE_TIMEOUT_IN_SECS)
     {
-      retval = receive_pno_data_frame();
-      if (ros::Time::now().toSec() - start_time.toSec() >= CALIBRATE_TIMEOUT_IN_SECS)
-      {
-        ROS_ERROR("[POLHEMUS] Caliration - error getting complete frame in required time.");
-        return -1;
-      }
+      ROS_ERROR("[POLHEMUS] Calibration - error getting complete frame in required time.");
+      return -1;
     }
+  }
 
   device_reset();
 }

--- a/src/polhemus_ros_driver/polhemus.cpp
+++ b/src/polhemus_ros_driver/polhemus.cpp
@@ -161,8 +161,6 @@ int Polhemus::set_device_for_calibration(void)
   int retval = RETURN_ERROR;
 
   reset_boresight();
-  reset_boresight();
-  reset_boresight();
 
   retval = receive_pno_data_frame();
   ros::Time start_time = ros::Time::now();

--- a/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
+++ b/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
@@ -356,7 +356,7 @@ int main(int argc, char** argv)
   retval = device->reset_boresight();
   if (RETURN_ERROR == retval)
   {
-    ROS_ERROR("[POLHEMUS] Error resetting device.");
+    ROS_ERROR("[POLHEMUS] Error resetting boresight.");
     return -1;
   }
 

--- a/src/polhemus_ros_driver/viper.cpp
+++ b/src/polhemus_ros_driver/viper.cpp
@@ -457,6 +457,7 @@ bool Viper::calibrate(std::string boresight_calibration_file)
 {
   int retval = RETURN_ERROR;
 
+  // set data mode to single to allow correct boresight reset
   device_data_mode(DATA_SINGLE);
 
   retval = set_device_for_calibration();

--- a/src/polhemus_ros_driver/viper.cpp
+++ b/src/polhemus_ros_driver/viper.cpp
@@ -79,7 +79,7 @@ int Viper::receive_data_frame(viper_cmds_e cmd_type)
   g_nrxcount = VIPER_RX_BUF_SIZE;
   retval = device_read(g_rxbuf, g_nrxcount, true);
 
-  if (retval != 0)
+  if (retval == 0)
   {
     CFrameInfo fi(g_rxbuf, g_nrxcount);
     if ((fi.cmd() != cmd_type) || !(fi.IsAck()))

--- a/src/polhemus_ros_driver/viper.cpp
+++ b/src/polhemus_ros_driver/viper.cpp
@@ -84,10 +84,10 @@ int Viper::receive_data_frame(viper_cmds_e cmd_type)
     CFrameInfo fi(g_rxbuf, g_nrxcount);
     if ((fi.cmd() != cmd_type) || !(fi.IsAck()))
     {
-      ROS_ERROR("[POLHEMUS] Error in message reply...\n");
-      ROS_ERROR("reply cmd: %d\n", fi.cmd());
-      ROS_ERROR("reply action: %d\n", fi.action());
-      ROS_ERROR("cmd sent: %d\n", cmd_type);
+      ROS_ERROR("[POLHEMUS] Error in message reply...");
+      ROS_ERROR("reply cmd: %d", fi.cmd());
+      ROS_ERROR("reply action: %d", fi.action());
+      ROS_ERROR("cmd sent: %d", cmd_type);
       retval = RETURN_ERROR;
     }
   }

--- a/src/polhemus_ros_driver/viper.cpp
+++ b/src/polhemus_ros_driver/viper.cpp
@@ -282,10 +282,12 @@ int Viper::reset_boresight(void)
   int nBytes = g_ntxcount;
   uint8_t *pbuf = g_txbuf;
   retval = device_send(pbuf, nBytes);
+
   if (retval == 0)
   {
     retval = receive_data_frame(cmd_type);
   }
+
   return retval;
 }
 
@@ -454,6 +456,9 @@ int Viper::send_saved_calibration(int number_of_hands)
 bool Viper::calibrate(std::string boresight_calibration_file)
 {
   int retval = RETURN_ERROR;
+
+  device_data_mode(DATA_SINGLE);
+
   retval = set_device_for_calibration();
   if (RETURN_ERROR == retval)
     return -1;

--- a/src/polhemus_ros_driver/viper.cpp
+++ b/src/polhemus_ros_driver/viper.cpp
@@ -79,15 +79,15 @@ int Viper::receive_data_frame(viper_cmds_e cmd_type)
   g_nrxcount = VIPER_RX_BUF_SIZE;
   retval = device_read(g_rxbuf, g_nrxcount, true);
 
-  if (retval == 0)
+  if (retval != 0)
   {
     CFrameInfo fi(g_rxbuf, g_nrxcount);
     if ((fi.cmd() != cmd_type) || !(fi.IsAck()))
     {
       ROS_ERROR("[POLHEMUS] Error in message reply...\n");
-      ROS_DEBUG("reply cmd: %d\n", fi.cmd());
-      ROS_DEBUG("reply action: %d\n", fi.action());
-      ROS_DEBUG("cmd sent: %d\n", cmd_type);
+      ROS_ERROR("reply cmd: %d\n", fi.cmd());
+      ROS_ERROR("reply action: %d\n", fi.action());
+      ROS_ERROR("cmd sent: %d\n", cmd_type);
       retval = RETURN_ERROR;
     }
   }


### PR DESCRIPTION
## Proposed changes

Small improvements in error checking. Set data to single mode to allow for device to correctly un-boresight. This allows user to boresight at runtime without the risk of writing wrong raw angle data to the calibration yaml file.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
