### PR TITLE
Check result and add retries when sending saved boresight to stations

### DIFF
--- a/src/polhemus_ros_driver/polhemus.cpp
+++ b/src/polhemus_ros_driver/polhemus.cpp
@@ -125,12 +125,8 @@ int Polhemus::device_read(void *pbuf, int &size, bool bTOisErr)
 
   latest_usb_read_result_ = return_value;
 
-  if ((return_value != LIBUSB_SUCCESS) && (return_value != LIBUSB_ERROR_TIMEOUT))
-  {
-    return_value = RETURN_ERROR;
-    size = 0;
-  }
-  else if ((return_value == LIBUSB_ERROR_TIMEOUT) && bTOisErr)
+  if (((return_value != LIBUSB_SUCCESS) && (return_value != LIBUSB_ERROR_TIMEOUT))
+      || ((return_value == LIBUSB_ERROR_TIMEOUT) && bTOisErr))
   {
     return_value = RETURN_ERROR;
     size = 0;

--- a/src/polhemus_ros_driver/polhemus.cpp
+++ b/src/polhemus_ros_driver/polhemus.cpp
@@ -167,7 +167,12 @@ int Polhemus::set_device_to_receive_saved_calibration()
         return -1;
       }
     }
-    device_reset();
+    return_value = device_reset();
+    if (return_value == RETURN_ERROR)
+    {
+      ROS_ERROR("[POLHEMUS] Calibration (boresight) - error resetting device.");
+      return RETURN_ERROR;
+    }
   }
   else
   {
@@ -180,9 +185,15 @@ int Polhemus::set_device_to_receive_saved_calibration()
 int Polhemus::set_device_for_calibration(void)
 {
   int return_value = RETURN_ERROR;
+  int nb_sensors;
   uint16_t required_number_of_sensors = sensors_right_glove + sensors_left_glove;
 
-  reset_boresight();
+  return_value = reset_boresight();
+  if (return_value == RETURN_ERROR)
+  {
+    ROS_ERROR("[POLHEMUS] Calibration (boresight) - error resetting boresight.");
+    return RETURN_ERROR;
+  }
 
   return_value = receive_pno_data_frame();
   ros::Time start_time = ros::Time::now();
@@ -196,9 +207,15 @@ int Polhemus::set_device_for_calibration(void)
       return -1;
     }
   }
+  nb_sensors = return_value;
 
-  device_reset();
-  return return_value;
+  return_value = device_reset();
+  if (return_value == RETURN_ERROR)
+  {
+    ROS_ERROR("[POLHEMUS] Calibration (boresight) - error resetting device.");
+    return RETURN_ERROR;
+  }
+  return nb_sensors;
 }
 
 void Polhemus::save_current_calibration_to_file(int station_id, int station_number)

--- a/src/polhemus_ros_driver/polhemus.cpp
+++ b/src/polhemus_ros_driver/polhemus.cpp
@@ -125,7 +125,12 @@ int Polhemus::device_read(void *pbuf, int &size, bool bTOisErr)
 
   latest_usb_read_result_ = return_value;
 
-  if ((return_value == LIBUSB_ERROR_TIMEOUT) && bTOisErr)
+  if ((return_value != LIBUSB_SUCCESS) && (return_value != LIBUSB_ERROR_TIMEOUT))
+  {
+    return_value = RETURN_ERROR;
+    size = 0;
+  }
+  else if ((return_value == LIBUSB_ERROR_TIMEOUT) && bTOisErr)
   {
     return_value = RETURN_ERROR;
     size = 0;

--- a/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
+++ b/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
@@ -459,6 +459,7 @@ int main(int argc, char** argv)
 
     if (sensor_count == -1)
     {
+      // TODO refactor this to get rid of this awful flag thingy
       if (flag == 0 || flag == 2)
       {
         ROS_DEBUG("[POLHEMUS] No position and orientation data received from Polhemus system!!!");

--- a/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
+++ b/src/polhemus_ros_driver/polhemus_tf_broadcaster.cpp
@@ -459,7 +459,7 @@ int main(int argc, char** argv)
 
     if (sensor_count == -1)
     {
-      // TODO refactor this to get rid of this awful flag thingy
+      // TODO(toni) refactor this to get rid of this awful flag thingy
       if (flag == 0 || flag == 2)
       {
         ROS_DEBUG("[POLHEMUS] No position and orientation data received from Polhemus system!!!");

--- a/src/polhemus_ros_driver/viper.cpp
+++ b/src/polhemus_ros_driver/viper.cpp
@@ -525,7 +525,12 @@ int Viper::send_saved_calibration()
     }
   }
 
-  device_data_mode(DATA_CONTINUOUS);
+  return_value = device_data_mode(DATA_CONTINUOUS);
+  if (RETURN_ERROR == return_value)
+  {
+    ROS_ERROR("[POLHEMUS] Error setting data mode to DATA_CONTINUOUS.");
+    return RETURN_ERROR;
+  }
   return 0;
 }
 
@@ -534,11 +539,18 @@ bool Viper::calibrate(std::string boresight_calibration_file)
   int return_value = RETURN_ERROR;
 
   // set data mode to single to allow correct boresight reset
-  device_data_mode(DATA_SINGLE);
+  return_value = device_data_mode(DATA_SINGLE);
+  if (RETURN_ERROR == return_value)
+  {
+    ROS_ERROR("[POLHEMUS] Error setting data mode to DATA_SINGLE.");
+    return false;
+  }
 
   return_value = set_device_for_calibration();
   if (RETURN_ERROR == return_value)
-    return -1;
+  {
+    return false;
+  }
 
   for (int station_number = 0; station_number < station_count; ++station_number)
   {
@@ -553,17 +565,27 @@ bool Viper::calibrate(std::string boresight_calibration_file)
   if (dump_calibration_param_status < 0)
   {
     ROS_ERROR("[POLHEMUS] Error saving calibration.");
-    return -1;
+    return false;
   }
   ROS_INFO("[POLHEMUS] Calibration file saved at: %s\n", boresight_calibration_file.c_str());
 
-  define_data_type(DATA_TYPE_EULER);
-  return_value = set_boresight(false, -1, 0, 0, 0);
-  define_data_type(DATA_TYPE_QUAT);
-
+  return_value = define_data_type(DATA_TYPE_EULER);
   if (RETURN_ERROR == return_value)
   {
-    ROS_ERROR("[POLHEMUS] Calibration failed.");
+    ROS_ERROR("[POLHEMUS] Error setting data type to EULER.");
+    return false;
+  }
+  return_value = set_boresight(false, -1, 0, 0, 0);
+  if (RETURN_ERROR == return_value)
+  {
+    ROS_ERROR("[POLHEMUS] Calibration (set_boresight) failed.");
+    return false;
+  }
+  return_value = define_data_type(DATA_TYPE_QUAT);
+  if (RETURN_ERROR == return_value)
+  {
+    ROS_ERROR("[POLHEMUS] Error setting data type to QUAT.");
+    return false;
   }
 
   // set data mode back to continuous
@@ -571,7 +593,7 @@ bool Viper::calibrate(std::string boresight_calibration_file)
   if (RETURN_ERROR == return_value)
   {
     ROS_ERROR("[POLHEMUS] Setting data mode to continuous, failed.\n");
-    return return_value;
+    return false;
   }
 
   return true;

--- a/src/polhemus_ros_driver/viper.cpp
+++ b/src/polhemus_ros_driver/viper.cpp
@@ -492,7 +492,7 @@ int Viper::send_saved_calibration()
 
     bool station_boresight_success = false;
     int nb_attempts = 5;
-    while(!station_boresight_success && nb_attempts > 0)
+    while (!station_boresight_success && nb_attempts > 0)
     {
       nb_attempts--;
       return_value = define_data_type(DATA_TYPE_EULER);

--- a/src/polhemus_ros_driver/viper.cpp
+++ b/src/polhemus_ros_driver/viper.cpp
@@ -490,13 +490,37 @@ int Viper::send_saved_calibration()
     float correction_pitch = station_pitch - calibrated_pitch;
     float correction_yaw = station_yaw - calibrated_yaw;
 
-    define_data_type(DATA_TYPE_EULER);
-    return_value = set_boresight(false, station_id, correction_yaw, correction_pitch, correction_roll);
-    define_data_type(DATA_TYPE_QUAT);
-
-    if (RETURN_ERROR == return_value)
+    bool station_boresight_success = false;
+    int nb_attempts = 5;
+    while(!station_boresight_success && nb_attempts > 0)
     {
-      ROS_ERROR("[POLHEMUS] Error sending calibration (boresight) from file.");
+      nb_attempts--;
+      return_value = define_data_type(DATA_TYPE_EULER);
+      if (RETURN_ERROR == return_value)
+      {
+        ROS_ERROR("[POLHEMUS] Error setting data type to EULER. %d attemps left.", nb_attempts);
+        continue;
+      }
+
+      return_value = set_boresight(false, station_id, correction_yaw, correction_pitch, correction_roll);
+      if (RETURN_ERROR == return_value)
+      {
+        ROS_ERROR("[POLHEMUS] Error sending calibration (boresight) from file. %d attemps left.", nb_attempts);
+        continue;
+      }
+
+      return_value = define_data_type(DATA_TYPE_QUAT);
+
+      if (RETURN_ERROR == return_value)
+      {
+        ROS_ERROR("[POLHEMUS] Error setting data type to QUAT. %d attemps left.", nb_attempts);
+        continue;
+      }
+      station_boresight_success = true;
+    }
+    if (!station_boresight_success)
+    {
+      ROS_ERROR("[POLHEMUS] Sending calibration (boresight) from file has failed.");
       return -1;
     }
   }


### PR DESCRIPTION
## Proposed changes

The changes in viper.cpp address the bug seen in the screenshots in this story https://shadowrobot.atlassian.net/browse/SRC-7274 where the call to `define_data_type(DATA_TYPE_EULER)`was very likely silently failing for one of the stations, resulting in the wrong units being used to boresight that station (fingertip sensor).

This PR adds check for the result of `define_data_type(...)` as well as retries if something fails, to guarantee that the boresight data will be correctly transmitted.

It also checks results and fixes return values for the `calibrate` method.

In `polemus.cpp` I've added checks for the result of `reset_boresight` and `device_reset`, as they are involved in the procedure to load the boresight data to the device.


## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
